### PR TITLE
Make @Bean methods static to avoid BeanPostProcessor warning

### DIFF
--- a/src/main/java/pl/allegro/tech/boot/leader/only/LeaderOnlyConfiguration.java
+++ b/src/main/java/pl/allegro/tech/boot/leader/only/LeaderOnlyConfiguration.java
@@ -9,13 +9,13 @@ import pl.allegro.tech.boot.leader.only.api.LeadershipFactory;
 @AutoConfiguration
 public class LeaderOnlyConfiguration {
     @Bean
-    LeadershipProxyFactory leaderOnlyProxyFactory(LeadershipFactory leadershipFactory) {
+    static LeadershipProxyFactory leaderOnlyProxyFactory(LeadershipFactory leadershipFactory) {
         return new LeadershipProxyFactory(leadershipFactory);
     }
 
     @Bean
     @ConditionalOnBean(LeadershipProxyFactory.class)
-    LeaderOnlyBeanPostProcessor leaderOnlyBeanPostProcessor(LeadershipProxyFactory leadershipProxyFactory) {
+    static LeaderOnlyBeanPostProcessor leaderOnlyBeanPostProcessor(LeadershipProxyFactory leadershipProxyFactory) {
         return new LeaderOnlyBeanPostProcessor(leadershipProxyFactory);
     }
 }


### PR DESCRIPTION
Non-static `@Bean` methods returning `BeanPostProcessor` instances cause Spring to eagerly instantiate the configuration class before all other post-processors are registered, resulting in a warning.

Making the `leaderOnlyProxyFactory` and `leaderOnlyBeanPostProcessor` methods `static` resolves this.